### PR TITLE
[Feat] Handle uat credentials

### DIFF
--- a/app/scripts/IngresseAPI.CookiesService.js
+++ b/app/scripts/IngresseAPI.CookiesService.js
@@ -17,15 +17,25 @@ angular.module('ingresseSDK')
     function _concat (cname) {
         var cookieName = '';
         var companyId  = ingresseApiPreferences.getCompanyId();
-        var env        = ingresseApiPreferences.getEnv();
-        var envConcat  = (env !== 'prod' ? (env + '_') : '');
+
+        function extractSubdomain() {
+            try {
+              const url = window.location.href;
+              const regex = /https:\/\/[^-]+-([^-]+)-[^.]+\.ingresse\.com/;
+              const match = url.match(regex);
+              return match ? match[1] : null;
+            } catch (error) {
+              return null;
+            }
+          }
+          const uatRef = extractSubdomain() ? 'uat-' + extractSubdomain() + '_' : '';
 
         return cookieName.concat(
             'ing',
             '_',
             companyId,
             '_',
-            envConcat,
+            uatRef,
             (cname || '')
         );
     };


### PR DESCRIPTION
# Description
O `websdk` não recebeu nenhuma atualização para lidar com os ambientes `uat`, para lidar com as requests foram feitos middlewares nas aplicações para redirecionar as requisições utilizando regex.
Esse PR tem com o objetivo identificar na `url` se existe `-texto-` entre o `https://` e o `.ingresse` sabendo assim conseguindo pegar por exemplo `neo` de `uat-neo-backstage`, dessa forma conseguimos capturar qual ambiente tá sendo utilizado na hora de acessar as credenciais nos cookies.

# Problema
Hoje em dia configuramos nosso `host` para rodar as portas em `local.ingresse.com:porta`, sendo que precisamos do ambiente na `url` para conseguir acessar a credential certa, logo, é aconselhável inserir também um host com o `uat` que estiver desenvolvendo, por exemplo:

```bash
127.0.0.1 uat-deploy-local.ingresse.com
::1       uat-deploy-local.ingresse.com localhost
```

# Sugestão
Essa não é a melhor forma de resolver esse problema, a melhor forma seria inserindo um argumento a mais nas funções do sdk para inserir o `env` utilizado, porém seria um impacto muito grande no `websdk` e em todas as aplicações que utilizam o `websdk`.
Dependendo de quanto tempo até o lançamento da próxima plataforma vale a pena investir em fazer essa transição aos poucos no `websdk`.